### PR TITLE
skip creation of preview resource

### DIFF
--- a/datapackage_pipelines_assembler/processors/load_modified_resources.py
+++ b/datapackage_pipelines_assembler/processors/load_modified_resources.py
@@ -22,9 +22,14 @@ def modify_datapackage(dp, parameters, stats):
     for url in urls:
         logging.info('URL: %s', url)
         dp_ = datapackage.DataPackage(url)
+        # Skip creation of preview resources if original resource is already small
+        if dp_.descriptor['datahub']['stats'].get('rowcount') == 0:
+            continue
         view = dp_.descriptor.get('views', [])
         views += view
 
+        if dp_.descriptor.get('not_processed'):
+            continue
         for resource_ in dp_.resources:
             resource: Resource = resource_
             descriptor = copy.deepcopy(resource.descriptor)

--- a/datapackage_pipelines_assembler/processors/load_modified_resources.py
+++ b/datapackage_pipelines_assembler/processors/load_modified_resources.py
@@ -28,8 +28,6 @@ def modify_datapackage(dp, parameters, stats):
         view = dp_.descriptor.get('views', [])
         views += view
 
-        if dp_.descriptor.get('not_processed'):
-            continue
         for resource_ in dp_.resources:
             resource: Resource = resource_
             descriptor = copy.deepcopy(resource.descriptor)

--- a/datapackage_pipelines_assembler/processors/load_preview.py
+++ b/datapackage_pipelines_assembler/processors/load_preview.py
@@ -4,6 +4,8 @@ parameters, datapackage, res_iter = ingest()
 
 
 def generate_preview(res):
+    if len(list(res)) < int(parameters.get('limit', 10000)):
+        return
     for i, row in enumerate(res):
         if i < int(parameters.get('limit', 10000)):
             yield row

--- a/datapackage_pipelines_assembler/processors/load_preview.py
+++ b/datapackage_pipelines_assembler/processors/load_preview.py
@@ -3,7 +3,7 @@ import collections
 from datapackage_pipelines.wrapper import spew, ingest
 
 parameters, datapackage, res_iter = ingest()
-limit = int(parameters.get('limit', 10000))
+limit = int(parameters.get('limit', 200))
 
 
 def generate_preview(res):

--- a/datapackage_pipelines_assembler/processors/load_preview.py
+++ b/datapackage_pipelines_assembler/processors/load_preview.py
@@ -1,19 +1,24 @@
+import collections
+
 from datapackage_pipelines.wrapper import spew, ingest
 
 parameters, datapackage, res_iter = ingest()
+limit = int(parameters.get('limit', 10000))
 
 
 def generate_preview(res):
-    if len(list(res)) < int(parameters.get('limit', 10000)):
-        return
     for i, row in enumerate(res):
-        if i < int(parameters.get('limit', 10000)):
+        if i < limit:
             yield row
 
 
 def process_resources(res_iter_):
     for res in res_iter_:
-        yield generate_preview(res)
+        if res.spec['rowcount'] > limit:
+            yield generate_preview(res)
+        else:
+            collections.deque(res, maxlen=0)
+            yield []
 
 
 spew(datapackage, process_resources(res_iter))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,3 +46,16 @@ class TestIndeedProccessors(unittest.TestCase):
 
         # should have 10 rows as limit is set to 10 in params
         self.assertEqual(len(rows), 10)
+
+        spew_args, _ = mock_processor_test(processor_path, ({'limit': '20'}, datapackage,[resources]))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        dp_resources = spew_dp['resources']
+
+        spew_res_iter_contents = list(spew_res_iter)
+        rows = list(list(spew_res_iter_contents)[0])
+
+        # should have 0 rows as original reource is already small
+        self.assertEqual(len(rows), 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,12 @@ class TestIndeedProccessors(unittest.TestCase):
             ]
         }
 
-        resources = [{'id': '%d'%i} for i in range(15)]
+        class TempList(list):
+            pass
+
+        resources = TempList([{'id': '%d'%i} for i in range(15)])
+        resources.spec = {'rowcount': 15}
+
 
         # Trigger the processor with mock `ingest` and capture what it will
         # returned to `spew`.


### PR DESCRIPTION
* preview processor returns `None` if the resource is less than limit.
* `load_modfied_resource` skips if row count of resource is 0
* Also change the limit to 1000
refs #31 and #32 