### PR TITLE
Event Store

### DIFF
--- a/datapackage_pipelines_assembler/generator.py
+++ b/datapackage_pipelines_assembler/generator.py
@@ -75,7 +75,6 @@ class Generator(GeneratorBase):
             else:
                 return '{ownerid}/{dataset}'.format(**meta)
 
-
         ownerid = meta['ownerid']
         owner = meta.get('owner')
         findability = meta.get('findability', 'published')

--- a/datapackage_pipelines_assembler/generator.py
+++ b/datapackage_pipelines_assembler/generator.py
@@ -6,8 +6,6 @@ from datapackage_pipelines.generators import (
 )
 from .nodes.planner import planner
 
-from .processors.dump_to_s3 import create_index # noqa
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/datapackage_pipelines_assembler/generator.py
+++ b/datapackage_pipelines_assembler/generator.py
@@ -77,6 +77,7 @@ class Generator(GeneratorBase):
             else:
                 return '{ownerid}/{dataset}'.format(**meta)
 
+
         ownerid = meta['ownerid']
         owner = meta.get('owner')
         findability = meta.get('findability', 'published')
@@ -154,6 +155,9 @@ class Generator(GeneratorBase):
             ('assembler.sample',),
         ]
         final_steps.extend(dump_steps(pipeline_id(), 'latest'))
+        final_steps.append(('assembler.add_indexing_resource', {
+            'flow-id': pipeline_id()
+        }))
         final_steps.append(
             ('elasticsearch.dump.to_index',
              {
@@ -162,6 +166,12 @@ class Generator(GeneratorBase):
                          {
                              'resource-name': '__datasets',
                              'doc-type': 'dataset'
+                         }
+                     ],
+                     'events': [
+                         {
+                             'resource-name': '__events',
+                             'doc-type': 'event'
                          }
                      ]
                  }

--- a/datapackage_pipelines_assembler/processors/add_indexing_resource.py
+++ b/datapackage_pipelines_assembler/processors/add_indexing_resource.py
@@ -6,16 +6,16 @@ from datapackage_pipelines.wrapper import ingest, spew
 
 SCHEMA = {
     'fields': [
-        {'name':'timestamp', 'type':'datetime'},
-        {'name':'event_entity', 'type':"string"},
-        {'name':'event_action', 'type':"string"},
-        {'name':'owner', 'type':'string'},
-        {'name':'ownerid', 'type':'string'},
-        {'name':'dataset', 'type':'string'},
-        {'name':'status', 'type':'string'},
-        {'name':'messsage', 'type':'string'},
-        {'name':'findability', 'type':'string'},
-        {'name':'payload', 'type': 'object', 'es:index': False}
+        {'name': 'timestamp', 'type': 'datetime'},
+        {'name': 'event_entity', 'type': "string"},
+        {'name': 'event_action', 'type': "string"},
+        {'name': 'owner', 'type': 'string'},
+        {'name': 'ownerid', 'type': 'string'},
+        {'name': 'dataset', 'type': 'string'},
+        {'name': 'status', 'type': 'string'},
+        {'name': 'messsage', 'type': 'string'},
+        {'name': 'findability', 'type': 'string'},
+        {'name': 'payload', 'type': 'object', 'es: index': False}
     ],
     'primaryKey': 'ownerid'
 }
@@ -31,9 +31,8 @@ def modify_datapackage(dp):
     return dp
 
 
-
 def dataset_resource(dp):
-    ret = dict(
+    yield dict(
         timestamp=datetime.datetime.now(),
         event_entity='flow',
         event_action='finished',
@@ -45,7 +44,6 @@ def dataset_resource(dp):
         findability=dp['datahub'].get('findability'),
         payload={'flow-id': parameters['flow-id']}
     )
-    yield ret
 
 
 if __name__ == "__main__":

--- a/datapackage_pipelines_assembler/processors/add_indexing_resource.py
+++ b/datapackage_pipelines_assembler/processors/add_indexing_resource.py
@@ -1,0 +1,54 @@
+import datetime
+import itertools
+
+from datapackage_pipelines.utilities.resources import PROP_STREAMING
+from datapackage_pipelines.wrapper import ingest, spew
+
+SCHEMA = {
+    'fields': [
+        {'name':'timestamp', 'type':'datetime'},
+        {'name':'event_entity', 'type':"string"},
+        {'name':'event_action', 'type':"string"},
+        {'name':'owner', 'type':'string'},
+        {'name':'ownerid', 'type':'string'},
+        {'name':'dataset', 'type':'string'},
+        {'name':'status', 'type':'string'},
+        {'name':'messsage', 'type':'string'},
+        {'name':'findability', 'type':'string'},
+        {'name':'payload', 'type': 'object', 'es:index': False}
+    ],
+    'primaryKey': 'ownerid'
+}
+
+
+def modify_datapackage(dp):
+    dp['resources'].append({
+        'name': '__events',
+        PROP_STREAMING: True,
+        'path': 'nonexistent',
+        'schema': SCHEMA
+    })
+    return dp
+
+
+
+def dataset_resource(dp):
+    ret = dict(
+        timestamp=datetime.datetime.now(),
+        event_entity='flow',
+        event_action='finished',
+        owner=dp['datahub'].get('owner'),
+        ownerid=dp['datahub'].get('ownerid'),
+        dataset=dp['name'],
+        status='OK',
+        messsage='',
+        findability=dp['datahub'].get('findability'),
+        payload={'flow-id': parameters['flow-id']}
+    )
+    yield ret
+
+
+if __name__ == "__main__":
+    parameters, dp, res_iter = ingest()
+    spew(modify_datapackage(dp),
+         itertools.chain(res_iter, [dataset_resource(dp)]))

--- a/datapackage_pipelines_assembler/processors/dump_to_s3.py
+++ b/datapackage_pipelines_assembler/processors/dump_to_s3.py
@@ -32,11 +32,6 @@ SCHEMA = {
 }
 
 
-def create_index(index_name):
-    storage = Storage()
-    storage.create(index_name, ('dataset', SCHEMA))
-
-
 def modify_datapackage(dp):
     dp['resources'].append({
         'name': '__datasets',

--- a/datapackage_pipelines_assembler/processors/dump_to_s3.py
+++ b/datapackage_pipelines_assembler/processors/dump_to_s3.py
@@ -1,7 +1,6 @@
 import copy
 
 from datapackage_pipelines.utilities.resources import PROP_STREAMING
-from tableschema_elasticsearch import Storage
 
 from datapackage_pipelines.wrapper import ingest, spew # noqa
 from datapackage_pipelines_aws.s3_dumper import S3Dumper


### PR DESCRIPTION
This pull request fixes #55

@akariv I added new processor for handling events index, as I could not find easy way to do this from `dump_to_s3` - whenever I try to do so, `load_modified_resources` in dpp is complaining about one additional resource that has no property `datahub`
This way it works fine and even thinking moving `datahub` index here as well. (Why is it in dump_to_s3 btw?)

Also, what do you think about events schema, do you think it is fine to go? cc @rufuspollock 