### PR TITLE
Remove index related stuff from dump_to_s3

### DIFF
--- a/datapackage_pipelines_assembler/processors/dump_to_s3.py
+++ b/datapackage_pipelines_assembler/processors/dump_to_s3.py
@@ -3,62 +3,8 @@ import datetime
 import os
 
 import filemanager
-from datapackage_pipelines.utilities.resources import PROP_STREAMING
 
 from datapackage_pipelines_aws.s3_dumper import S3Dumper
-
-
-SCHEMA = {
-    'fields': [
-        {'name': 'id', 'type': 'string'},
-        {'name': 'name', 'type': 'string'},
-        {'name': 'title', 'type': 'string'},
-        {'name': 'description', 'type': 'string'},
-        {'name': 'datapackage', 'type': 'object', 'es:index': False},
-        {'name': 'datahub', 'type': 'object',
-         'es:schema': {
-             'fields': [
-                 {'name': 'owner', 'type': 'string'},
-                 {'name': 'ownerid', 'type': 'string'},
-                 {'name': 'findability', 'type': 'string'},
-                 {'name': 'flowid', 'type': 'string'},
-                 {'name': 'stats', 'type': 'object', 'es:schema': {
-                    'fields': [
-                        {'name': 'rowcount', 'type': 'integer'},
-                        {'name': 'bytes', 'type': 'integer'}
-                    ]}}
-             ]}
-         },
-    ],
-    'primaryKey': ['id']
-}
-
-
-def modify_datapackage(dp):
-    dp['resources'].append({
-        'name': '__datasets',
-        PROP_STREAMING: True,
-        'path': 'nonexistent',
-        'schema': SCHEMA
-    })
-    return dp
-
-
-def dataset_resource(dp):
-    ret = dict(
-        (k, dp.get(k))
-        for k in [
-            'id',
-            'name',
-            'title',
-            'description',
-            'datahub'
-        ]
-    )
-    dp = copy.deepcopy(dp)
-    dp['resources'].pop()
-    ret['datapackage'] = dp
-    yield ret
 
 
 class MyS3Dumper(S3Dumper):
@@ -66,30 +12,6 @@ class MyS3Dumper(S3Dumper):
     def __init__(self):
         super(MyS3Dumper, self).__init__()
         self.fm = filemanager.FileManager(os.environ.get('FILEMANAGER_DATABASE_URL'))
-
-    def initialize(self, params):
-        super(MyS3Dumper, self).initialize(params)
-        self.final = params.get('final', False)
-
-    def prepare_datapackage(self, datapackage, params):
-        datapackage = super(MyS3Dumper, self).prepare_datapackage(datapackage, params)
-        if self.final:
-            return modify_datapackage(datapackage)
-        else:
-            return datapackage
-
-    def handle_datapackage(self, datapackage, parameters, stats):
-        if self.final:
-            dp = copy.deepcopy(datapackage)
-            dp['resources'].pop()
-        else:
-            dp = datapackage
-        return super(MyS3Dumper, self).handle_datapackage(dp, parameters, stats)
-
-    def handle_resources(self, datapackage, resource_iterator, parameters, stats):
-        yield from super(MyS3Dumper, self).handle_resources(datapackage, resource_iterator, parameters, stats)
-        if self.final:
-            yield dataset_resource(datapackage)
 
     def put_object(self, **kwargs):
         super(MyS3Dumper, self).put_object(**kwargs)

--- a/datapackage_pipelines_assembler/processors/dump_to_s3.py
+++ b/datapackage_pipelines_assembler/processors/dump_to_s3.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ https://github.com/datahq/planner/archive/master.zip
 https://github.com/datahq/specstore/archive/master.zip
 https://github.com/datahq/events/archive/master.zip
 https://github.com/datahq/filemanager/archive/master.zip
-datapackage-pipelines-elasticsearch>=0.0.6
 datapackage-pipelines-aws>=0.0.19
 goodtables>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ INSTALL_REQUIRES = [
     'psycopg2',
     'tweepy',
     'facebook-sdk',
-    'google-api-python-client==1.5.3',
-    'datapackage-pipelines-elasticsearch'
+    'google-api-python-client==1.5.3'
 ]
 DEPENDENCY_LINKS=[
     'https://github.com/datahq/specstore/archive/master.zip'

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -315,7 +315,7 @@ class TestFlow(unittest.TestCase):
             os.path.realpath(__file__)), 'inputs/invalid_file'), config=config)
 
         # Specstore
-        time.sleep(5)
+        time.sleep(10)
         res = requests.get(info_latest % 'invalid-file')
         self.assertEqual(res.status_code, 200)
 
@@ -448,6 +448,7 @@ class TestFlow(unittest.TestCase):
         # TODO: compare zip files
 
         # Elasticsearch
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -464,7 +465,6 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(datahub['stats']['rowcount'], 20)
         self.assertEqual(len(datapackage['resources']), 5)
 
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -565,6 +565,7 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
         # Elasticsearch
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -580,7 +581,6 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(datahub['stats']['rowcount'], 40)
         self.assertEqual(len(datapackage['resources']), 8)
 
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -661,6 +661,7 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
         # Elasticsearch
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -676,7 +677,6 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(datahub['stats']['rowcount'], 20)
         self.assertEqual(len(datapackage['resources']), 5)
 
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -754,7 +754,7 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
         # Elasticsearch
-        time.sleep(5)
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -847,7 +847,7 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
         # Elasticsearch
-        time.sleep(5)
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -938,6 +938,7 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(res.status_code, 403)
 
         # Elasticsearch
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -954,7 +955,6 @@ class TestFlow(unittest.TestCase):
         self.assertEqual(datahub['stats']['rowcount'], 20)
         self.assertEqual(len(datapackage['resources']), 5)
 
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         self.assertEqual(res.status_code, 200)
 
@@ -992,10 +992,10 @@ class TestFlow(unittest.TestCase):
         # Run flow
         run_factory(os.path.join(os.path.dirname(
             os.path.realpath(__file__)), 'inputs/single_file'))
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         meta = res.json()
         self.assertEqual(meta['hits']['total'], 1)
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         events = res.json()
         self.assertEqual(events['hits']['total'], 1)
@@ -1003,10 +1003,10 @@ class TestFlow(unittest.TestCase):
         # Second flow
         run_factory(os.path.join(os.path.dirname(
             os.path.realpath(__file__)), 'inputs/multiple_files'))
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         meta = res.json()
         self.assertEqual(meta['hits']['total'], 2)
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         events = res.json()
         self.assertEqual(events['hits']['total'], 2)
@@ -1014,10 +1014,10 @@ class TestFlow(unittest.TestCase):
         # Third flows
         run_factory(os.path.join(os.path.dirname(
             os.path.realpath(__file__)), 'inputs/excel'))
+        time.sleep(15)
         res = requests.get('http://localhost:9200/datahub/_search')
         meta = res.json()
         self.assertEqual(meta['hits']['total'], 3)
-        time.sleep(5)
         res = requests.get('http://localhost:9200/events/_search')
         events = res.json()
         self.assertEqual(events['hits']['total'], 3)


### PR DESCRIPTION
This pull request refs https://github.com/datahq/specstore/issues/28 .

* [x] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- removed resource preparation steps from dump_to_s3
- increase sleep time as now indexing from specstore needs more time
  

Note: this two PR should be merged for tests to be passing
* specstore: https://github.com/datahq/specstore/pull/29
* planner: https://github.com/datahq/planner/pull/17