### PR TITLE
[processors][m]: processor for extracting readme for zip -

### DIFF
--- a/datapackage_pipelines_assembler/processors/extract_readme.py
+++ b/datapackage_pipelines_assembler/processors/extract_readme.py
@@ -1,0 +1,28 @@
+from tempfile import mkdtemp
+from os import path
+
+from datapackage_pipelines.wrapper import spew, ingest
+from datapackage_pipelines.utilities.resources import PROP_STREAMED_FROM
+
+parameters, datapackage, res_iter = ingest()
+readme_name = path.join(mkdtemp(), 'README.md')
+
+
+def exctract_readme(datapackage_):
+    readme = datapackage_.pop('readme', None)
+    if readme is None:
+        return datapackage_
+
+    with open(readme_name, 'w') as f:
+        f.write(readme)
+
+    datapackage_['resources'].append({
+        PROP_STREAMED_FROM: readme_name,
+        'name': 'readme',
+        'format': 'md',
+        'path': 'README.md'
+    })
+
+    return datapackage_
+
+spew(exctract_readme(datapackage), res_iter)

--- a/datapackage_pipelines_assembler/processors/extract_readme.py
+++ b/datapackage_pipelines_assembler/processors/extract_readme.py
@@ -25,4 +25,5 @@ def exctract_readme(datapackage_):
 
     return datapackage_
 
+
 spew(exctract_readme(datapackage), res_iter)

--- a/tests/inputs/single_file/datapackage.json
+++ b/tests/inputs/single_file/datapackage.json
@@ -23,5 +23,6 @@
         "primaryKey": "date"
       }
     }
-  ]
+  ],
+  "readme": "Hello World"
 }

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -112,3 +112,34 @@ class TestIndeedProccessors(unittest.TestCase):
         del result['hash']
 
         self.assertDictEqual(expected, result)
+
+
+    def test_extract_readme(self):
+
+        # Path to the processor we want to test
+        processor_dir = os.path.dirname(datapackage_pipelines_assembler.processors.__file__)
+        processor_path = os.path.join(processor_dir, 'extract_readme.py')
+
+        datapackage = {
+            "name": "test",
+            "resources": [],
+            "readme": "Hellow world"
+        }
+
+        spew_args, _ = mock_processor_test(processor_path, ({}, datapackage,[[]]))
+
+        spew_dp = spew_args[0]
+        spew_res_iter = spew_args[1]
+
+        expected = {
+            "name": "test",
+            "resources": [{
+              "format": "md",
+              "name": "readme",
+              "path": "README.md"
+            }]
+        }
+
+        del spew_dp['resources'][0][PROP_STREAMED_FROM]
+
+        self.assertDictEqual(expected, spew_dp)


### PR DESCRIPTION
This pull request fixes #91 .

To include README in zipping we need a simple processor to extract it from dp.json. PR introduces `extract_readme` processor that grabs readme if present and creates in tempdir, That later will be dumped to zip.